### PR TITLE
Add mail_smarthost_port for sendmail relay on different port

### DIFF
--- a/custom/cfg/global/script/20-sendmail.sh
+++ b/custom/cfg/global/script/20-sendmail.sh
@@ -15,6 +15,12 @@ if [[ ${CONFIG_mail_smarthost} ]]; then
 	cp /etc/mail/{submit.cf,sendmail.cf} /tmp/
 	sed "s:^DS$:DS[${CONFIG_mail_smarthost}]:g" /tmp/submit.cf   > /etc/mail/submit.cf
 	sed "s:^DS$:DS[${CONFIG_mail_smarthost}]:g" /tmp/sendmail.cf > /etc/mail/sendmail.cf
+	## Sendmail relay port (ex 587)
+	if [[ ${CONFIG_mail_smarthost_port} ]]; then
+		cp /etc/mail/{submit.cf,sendmail.cf} /tmp/
+		sed "/^Mrelay/,+2 s:\(A=TCP \$h\)$:\1 ${CONFIG_mail_smarthost_port}:" /tmp/submit.cf   > /etc/mail/submit.cf
+		sed "/^Mrelay/,+2 s:\(A=TCP \$h\)$:\1 ${CONFIG_mail_smarthost_port}:" /tmp/sendmail.cf > /etc/mail/sendmail.cf
+	fi
 fi
 
 ## Possibility to modify the sender domian name, default FQDN


### PR DESCRIPTION
Hi,

I would like to add a sendmail option to specify relay mail submission port

One of my ISPs does not allow outbound port 25
My mail relay allows inbound 587

This seems to work for me. I am not sure if this is the correct way to implement.

Setting found at [Wing Loon—Sendmail relay with port example](http://wingloon.com/2008/04/06/setup-smart-relay-host-port-in-sendmail/)

Cheers